### PR TITLE
Add documentation warnings for Chess v1-LLM API key security and costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Key features include:
 - **Resilient Connectivity**: Built-in retry logic and a "paused" state handle network issues or API limits without losing game progress.
 - **Detailed Logging**: A comprehensive export feature captures the full game log, including PGN, FEN, and the LLM's internal commentary for each move, which is valuable for reinforcement learning research and analysis.
 
+> [!WARNING]
+> Users should exercise caution when configuring LLM API keys. To prevent unauthorized access to your credentials, it is recommended to access the Chess v1-LLM application via `file:///` or serve to `localhost` only. Additionally, monitor your API usage as LLM queries may incur costs from your provider.
+
 ### Screenshot
 
 ![Chess LLM Screenshot 1](docs/images/screenshot_1_chess_llm.png)

--- a/chess-v1-llm/README.md
+++ b/chess-v1-llm/README.md
@@ -17,6 +17,17 @@ To enable the LLM opponent, you must configure a valid API key and endpoint. The
 
 The game will automatically save your configuration (excluding the API key) to the browser's local storage.
 
+## Security and Usage Warning
+
+> [!IMPORTANT]
+> **Security Risk**: If you configure the application using a `llm_config.json` file, your API key is stored in plain text within that file. If this application is served on the public internet, the `llm_config.json` file may be accessible to unauthorized users, exposing your API key.
+>
+> To protect your credentials, it is **highly recommended** to:
+> - Access the application via `file:///` protocol.
+> - Or, serve the application only to `localhost` (127.0.0.1).
+>
+> **Usage Costs**: Be aware that using LLM providers typically incurs costs per query. Users should monitor their API usage and billing through their respective provider's dashboard.
+
 ### Configuration via File (`llm_config.json`)
 
 You can also pre-configure the application by creating a file named `llm_config.json` in the same directory as `index.html`. The application will attempt to load this file automatically on startup.


### PR DESCRIPTION
This change adds security and usage warnings to the documentation for Chess v1-LLM. Specifically, it warns about the risk of exposing API keys in the `llm_config.json` file when the application is served on the public internet. It recommends accessing the application via `file:///` or `localhost` to mitigate this risk. Additionally, it advises users to monitor their API usage and costs.

---
*PR created automatically by Jules for task [7597467772403063458](https://jules.google.com/task/7597467772403063458) started by @bob-friedman*