### PR TITLE
Update main README and add Grid Combat Autoresearch documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,73 @@ Each skirmish is a core force (2 Infantry, 1 Mech, 2 Tanks) plus randomized supp
 ### Screenshot
 
 ![Grid Combat Screenshot 1](docs/images/screenshot_1_gridcombat.png)
+
+### Autoresearch — Autonomous AI Improvement
+
+This section documents an autonomous research system developed for iterative improvement of the Grid Combat AI heuristic (`ai.js`) on constrained hardware. It is released as open scientific work for researchers with access to greater computational resources.
+
+A closed loop runs on Google Colab (free tier, T4 GPU). A local language model proposes modifications to `ai.js`; a Node.js evaluator measures win rate across 200 games; the harness commits, evaluates, and keeps or reverts each change without human intervention. All progress is persisted to Google Drive via a git bundle, surviving session expiry.
+
+The system implements two complementary loops. Loop 1 runs autonomously and is suited to parameter tuning and simple heuristic additions. Loop 2 is human-guided and addresses targeted algorithmic changes — for example, correcting ranged unit positioning — that win rate alone cannot diagnose. A Loop 2 change is injected into `ai.js` manually, then Loop 1 resumes and fine-tunes within the expanded capability.
+
+```mermaid
+flowchart TD
+    subgraph L1["Loop 1 — Autoresearch (continuous)"]
+        A([Start / Resume]) --> B[Read ai.js<br/>+ build prompt]
+        B --> C["Local inference<br/>Qwen2.5-3B · ~12 min"]
+        C --> D{Parse<br/>response}
+        D -- "no JS found" --> B
+        D -- "JS extracted" --> E{Sanity<br/>check}
+        E -- fail --> B
+        E -- pass --> F[git commit ai.js]
+        F --> G["Evaluate<br/>200 games · Node.js"]
+        G --> H{win_rate<br/>returned?}
+        H -- crash --> I["Revert<br/>git reset --hard<br/>store error tail"]
+        I --> B
+        H -- yes --> J{win_rate<br/>> best?}
+        J -- no --> K["Discard<br/>git reset --hard"]
+        K --> B
+        J -- yes --> L["Keep<br/>update best<br/>save bundle to Drive"]
+        L --> B
+    end
+
+    subgraph L2["Loop 2 — Directed Research (human-guided)"]
+        M["Observe gameplay<br/>identify failure mode"]
+        M --> N["Reason with game constants<br/>damage tables · code structure"]
+        N --> O["Write targeted change<br/>to ai.js"]
+        O --> P[git commit<br/>git bundle save]
+    end
+
+    P -- "inject & resume" --> A
+```
+
+#### Empirical Results
+
+| Metric | Value |
+| :--- | :--- |
+| Baseline win rate | 50.0% |
+| Best achieved | 61.75% (Experiment #1) |
+| Gain | +11.75 points |
+| Evaluator | 200 games · 4 scenarios · noise ≈ 1.5 pts |
+| Model | Qwen2.5-3B-Instruct · 4-bit NF4 |
+| Hardware | Google Colab T4 · 16 GB VRAM |
+| Inference time | ~12 minutes per experiment |
+
+#### Findings
+
+**Established.** The harness is correct and produces real results. An 11.75-point gain in the first successful experiment confirms the pipeline generates genuine improvement.
+
+**Null hypothesis confirmed.** A 3B parameter model is insufficient for sustained autonomous code modification. Seven consecutive crashes at the same file location with identical proposals confirm the model fixates rather than explores under iterative agentic load. This is a capacity constraint, not a harness or prompt deficiency. It is a known boundary condition of small models in agentic use.
+
+**Open question.** Whether the win rate gain translates to harder human play is untested and is the sole criterion of practical success for this project.
+
+#### Future Direction
+
+A more capable small model (3B–4B) with stronger long-form code generation may resolve the fixation pattern without exceeding T4 constraints. The architecture requires no change — only a model ID update. The harness, evaluator, git strategy, and two-loop design are valid at any model size.
+
+#### Reproducing This System
+
+Requirements: Google Colab account with GPU runtime (T4 free tier is sufficient). The notebook `GridCombat_Autoresearch.ipynb` contains all cells, configuration, and documentation. Upload `ai.js`, `baseline_ai.js`, `game_core.js`, and `evaluate.js` to Colab, then run cells in order. On session restart, skip only Cell 5 (initial commit). The git bundle on Drive preserves all progress across sessions.
 ___
 ## Installation
 
@@ -233,4 +300,7 @@ The game logic for Grid Combat is contained in `grid-combat/game.js`. The follow
 
 ## Contributors
 
-The development of the software and code benefited significantly from discussions and iterative refinement with an AI language model, Gemini 2.5 Pro (Google). The author oversaw and reviewed the accuracy and robustness of all parts of its development.
+The development of the software and code benefited significantly from discussions and iterative refinement with AI language models. The author oversaw and reviewed the accuracy and robustness of all parts of its development.
+
+-   **Gemini 2.5 Pro** (Google) — primary development of the game collection and RL data retrieval interfaces.
+-   **Claude Sonnet** (Anthropic) — design and implementation of the Grid Combat Autoresearch system, including the two-loop architecture, experiment harness, evaluator, git persistence strategy, and formal documentation of findings.

--- a/grid-combat/AUTORESEARCH.md
+++ b/grid-combat/AUTORESEARCH.md
@@ -1,0 +1,218 @@
+# GridCombat Autoresearch
+
+An autonomous research instrument for iterative game AI improvement on constrained hardware.
+Built for Google Colab free tier (T4 GPU). Documented and released as open scientific work.
+
+---
+
+## What This Is
+
+This notebook implements a closed-loop system that autonomously proposes, evaluates, and
+commits modifications to a game AI heuristic (`ai.js`) for a turn-based strategy game.
+A local language model generates code changes; a Node.js evaluator measures win rate across
+200 games; the harness keeps or reverts each change and loops. No human intervention is
+required between experiments.
+
+The system is not a prototype. It is a complete, documented, reproducible research instrument
+with a formal findings section. Its contribution is the architecture, the constraints it
+navigates, and the boundary conditions it establishes — not the win rate number alone.
+
+---
+
+## Empirical Result
+
+| Metric | Value |
+|---|---|
+| Baseline win rate | 50.0% |
+| Best achieved | 61.75% (Experiment #1) |
+| Gain | +11.75 points |
+| Evaluator | 200 games · 4 scenarios · noise ≈ 1.5 pts |
+| Model | Qwen2.5-3B-Instruct · 4-bit NF4 |
+| Hardware | Google Colab T4 · 16 GB VRAM |
+| Time per experiment | ~12 minutes |
+
+---
+
+## Architecture — Two Complementary Loops
+
+The system implements two loops operating at different levels. They are not redundant.
+
+### Loop 1 — Autoresearch (this notebook)
+
+Runs continuously without human input. The model makes small, focused changes guided solely
+by win rate. Its value is iteration rate and parametric optimisation — not algorithmic reasoning.
+
+Capable of: parameter tuning, simple heuristic additions, emergent behavioural correction.
+
+Not capable of: diagnosing systemic failures, producing substantial algorithmic additions,
+or reasoning from game state it cannot observe.
+
+### Loop 2 — Directed Research (human-guided)
+
+Human observation of gameplay identifies specific failure modes — for example, ranged units
+advancing past the front line. These are reasoned about with reference to game constants,
+damage tables, and code structure. The result is a targeted algorithmic addition that
+Loop 1 cannot discover on its own.
+
+Output is injected into `ai.js` manually, then Loop 1 resumes and fine-tunes within the
+expanded capability.
+
+**Injection protocol:**
+```bash
+# 1. Interrupt Cell 8
+# 2. Edit ai.js directly
+git add ai.js && git commit -m 'directed: description of change'
+git bundle create "$BUNDLE_PATH" --all
+# 3. Resume Cell 8
+```
+
+### Division of Labour
+
+| Class of change | Loop 1 | Loop 2 |
+|---|---|---|
+| Parameter tuning | Yes | No |
+| Emergent behavioural correction | Yes | No |
+| Simple heuristic additions | Occasionally | Yes |
+| Targeted fix for a known failure | No | Yes |
+| Substantial algorithmic additions | No | Yes |
+
+---
+
+## Experiment Cycle (Loop 1)
+
+```
+Inference → Parse → Sanity check → Commit → Evaluate → Keep / Discard / Crash
+    ↑                                                          |
+    └──────────────────────── loop ────────────────────────────┘
+```
+
+On **crash**: the evaluator error tail is stored and prepended to the next prompt, so
+the model sees what broke. This does not resolve the capacity constraint but closes an
+information gap.
+
+On **keep**: the git bundle is saved to Google Drive immediately. Session expiry
+is non-destructive — the best `ai.js` and full commit history survive.
+
+On **discard**: `git reset --hard` reverts to the prior best. The result is logged.
+
+---
+
+## Findings
+
+### Established
+
+The harness is correct and produces real results. It handles inference failures, syntax
+errors, missing required functions, and session interruption without human intervention.
+An 11.75-point gain in experiment #1 confirms the pipeline generates genuine improvement.
+
+The Qwen2.5-3B-Instruct model at 4-bit NF4 quantization is the correct instrument for
+this loop on a T4 GPU. Larger models exceed available VRAM or inference time budgets.
+
+### Refuted — Null Hypothesis Confirmed
+
+**A 3B parameter model is insufficient for sustained autonomous code modification.**
+
+Seven consecutive crashes at the same file location with identical proposals confirm the
+model fixates rather than explores and degrades at a predictable point in every generation.
+This is not a problem of the prompt or configuration. It is a known boundary condition
+of small models under iterative agentic load. The harness compensates for individual
+failures but cannot compensate for a model that cannot genuinely vary its proposals.
+
+The technical cause is well established: models below approximately 7B parameters lose
+syntactic coherence under long-form code generation. The model maintains structural
+integrity in the early portion of a file and degrades as the context fills — producing
+a consistent crash at a predictable location rather than a random one.
+
+### Open
+
+Whether the 11.75-point win rate gain translates to harder human play is untested.
+These are independent questions. An AI can improve against a fixed baseline while
+remaining trivially exploitable by a human who plays differently. Both must be
+evaluated separately.
+
+---
+
+## Hardware and Platform Constraints
+
+| Constraint | Value | Consequence |
+|---|---|---|
+| T4 VRAM | 16 GB total | 7B model exhausts inference buffer; 3B is the ceiling at 4-bit NF4 |
+| Inference time | ~12 min / experiment | ~60 experiments per session maximum |
+| Session duration | Unpredictable; ~1.5 hr observed | Manual restart required; model re-downloads (~6 GB) each session |
+| Evaluator noise | ≈ 1.5 win rate points | Changes below this threshold are indistinguishable from noise |
+| Storage | Google Drive bundle | Git history and best ai.js survive session expiry; model does not |
+
+---
+
+## Future Direction
+
+**A more capable small model.** As the Qwen family and others advance, a future 3B–4B
+model with stronger instruction-following and long-form code generation capability may
+resolve the fixation and degradation pattern without exceeding T4 constraints. The
+architecture requires no change — only a `MODEL_ID` update in Cell 6. The harness,
+evaluator, git strategy, and two-loop design remain valid at any model size.
+
+This is the only direction identified as tractable within current constraints. It is
+not actionable until a suitable model exists. Continuing sessions with the current model
+beyond what the evidence already establishes is not a productive use of the resource.
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `GridCombat_Autoresearch.ipynb` | The notebook — all cells, all documentation |
+| `ai.js` | The AI under research (modified by the loop) |
+| `baseline_ai.js` | Fixed opponent AI (never modified) |
+| `game_core.js` | Game engine (read-only) |
+| `evaluate.js` | Evaluator — runs 200 games, prints win_rate |
+| `results.tsv` | Experiment log — commit, win_rate, status, description |
+| `repo.bundle` | Git bundle saved to Drive on every KEEP |
+
+---
+
+## Reproducing This System
+
+Requirements: Google account with Colab access and GPU runtime (T4 free tier is sufficient).
+
+1. Open the notebook in Colab and select a GPU runtime.
+2. Run Cell 1 (Drive mount and paths).
+3. Run Cell 2 (Node.js and Python packages).
+4. Run Cell 3 (git identity).
+5. Upload `ai.js`, `baseline_ai.js`, `game_core.js`, `evaluate.js` via the Colab file browser.
+6. Run Cell 4 (repo setup) and Cell 5 (initial commit — first run only).
+7. Run Cell 6 (model load — ~3–4 minutes).
+8. Run Cell 7 (orchestrator definitions).
+9. Run Cell 8 (experiment loop — runs until interrupted or session expires).
+
+On session restart: re-run Cells 1, 2, 3, 4, 6, 7, 8. Skip Cell 5.
+
+---
+
+## On the Value of This Work
+
+The win rate number is not the primary contribution. The contribution is the system itself:
+a reproducible, formally documented research instrument that establishes what is and is not
+achievable within these constraints. It saves subsequent researchers the weeks required to
+rediscover these boundary conditions independently.
+
+The null hypothesis is confirmed. The boundary is known. The architecture is sound. The next
+advance requires only a more capable model at the same hardware budget — a condition that
+will be met as the field progresses.
+
+This work is released to the community without reservation.
+
+---
+
+## Research Note — On Session Design
+
+Each Colab session yields approximately 60 experiments. This is not a platform for sustained
+convergence over weeks. It is a tool for capturing large, obvious improvements in deliberate,
+hypothesis-driven sessions.
+
+The question before each session: *what specific improvement do we predict exists, and what
+result would refute that prediction?*
+
+Unfocused continuation across many sessions produces noise rather than knowledge. Resources
+are finite. Time is irreplaceable.

--- a/grid-combat/GridCombat_Autoresearch.ipynb
+++ b/grid-combat/GridCombat_Autoresearch.ipynb
@@ -1,0 +1,391 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  },
+  "accelerator": "GPU",
+  "colab": {
+   "provenance": []
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "md-title",
+   "metadata": {
+    "id": "md-title"
+   },
+   "source": [
+    "# GridCombat Autoresearch — Colab Edition\n\n",
+    "**Runtime required:** GPU — T4 (free tier) is sufficient for Qwen 2.5 3B at 4-bit\n\n",
+    "| Cell | Type   | Purpose |\n",
+    "|------|--------|---------|\n",
+    "| 1    | Python | Mount Drive, set path constants, export as env vars |\n",
+    "| 2    | Bash   | Install Node.js and Python packages |\n",
+    "| 3    | Bash   | Configure git identity |\n",
+    "| 4    | Bash   | Repo setup: restore from Drive bundle or initialise a new git repository |\n",
+    "| 5    | Bash   | First run only: copy JS files, make initial commit, and save bundle to Drive |\n",
+    "| 6    | Python | Load Qwen 2.5 3B Instruct at 4-bit |\n",
+    "| 7    | Python | Define all orchestrator functions (read before running 8) |\n",
+    "| 8    | Python | Run the experiment loop |\n\n",
+    "**Resuming after session expiry:** re-run cells 1, 2, 3, 4, 6, 7, 8. Skip cell 5."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-c1",
+   "metadata": {
+    "id": "md-c1"
+   },
+   "source": [
+    "## Cell 1 (Python) — Mount Drive and export paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1-drive",
+   "metadata": {
+    "id": "c1-drive"
+   },
+   "outputs": [],
+   "source": [
+    "from google.colab import drive\n",
+    "import os\n",
+    "drive.mount('/content/drive')\n\n",
+    "DRIVE_ROOT  = '/content/drive/MyDrive/gridcombat'\n",
+    "WORK_DIR    = '/content/gridcombat'\n",
+    "MODEL_CACHE = '/content/model_cache'\n",
+    "BUNDLE_PATH = '/content/drive/MyDrive/gridcombat/repo.bundle'\n\n",
+    "os.environ['DRIVE_ROOT']  = DRIVE_ROOT\n",
+    "os.environ['WORK_DIR']    = WORK_DIR\n",
+    "os.environ['MODEL_CACHE'] = MODEL_CACHE\n",
+    "os.environ['BUNDLE_PATH'] = BUNDLE_PATH\n\n",
+    "os.makedirs(DRIVE_ROOT,  exist_ok=True)\n",
+    "os.makedirs(WORK_DIR,    exist_ok=True)\n",
+    "os.makedirs(MODEL_CACHE, exist_ok=True)\n\n",
+    "print(f'Drive root  : {DRIVE_ROOT}')\n",
+    "print(f'Work dir    : {WORK_DIR}')\n",
+    "print(f'Model cache : {MODEL_CACHE}')\n",
+    "print(f'Bundle path : {BUNDLE_PATH}')\n",
+    "print('Drive mounted OK.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-c2",
+   "metadata": {
+    "id": "md-c2"
+   },
+   "source": [
+    "## Cell 2 (Bash) — Install Node.js and Python packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2-deps",
+   "metadata": {
+    "id": "c2-deps"
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "echo '--- Node.js ---'\n",
+    "if ! command -v node &> /dev/null; then\n",
+    "    apt-get install -y nodejs 2>&1 | tail -3\n",
+    "fi\n",
+    "node --version\n\n",
+    "echo '--- Python packages ---'\n",
+    "pip install -q transformers accelerate bitsandbytes\n\n",
+    "echo 'Done.'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-c3",
+   "metadata": {
+    "id": "md-c3"
+   },
+   "source": [
+    "## Cell 3 (Bash) — Configure git identity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3-gitconfig",
+   "metadata": {
+    "id": "c3-gitconfig"
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "git config --global user.email 'autoresearch@colab.local'\n",
+    "git config --global user.name  'Autoresearch Bot'\n",
+    "git config --global init.defaultBranch main\n",
+    "echo 'Git identity:'\n",
+    "git config --global --list | grep user"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-c4",
+   "metadata": {
+    "id": "md-c4"
+   },
+   "source": [
+    "## Cell 4 (Bash) — Repo setup\n\n",
+    "Restores from Drive bundle if a previous session exists; otherwise initialises a new git repository.\n",
+    "Safe to re-run on session restart."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4-repo",
+   "metadata": {
+    "id": "c4-repo"
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "mkdir -p \"$WORK_DIR\"\n",
+    "cd \"$WORK_DIR\"\n\n",
+    "if [ -f \"$BUNDLE_PATH\" ]; then\n",
+    "    echo 'Bundle found on Drive -- restoring repo...'\n",
+    "    if [ -d .git ]; then\n",
+    "        echo 'Repo already present, fetching latest from bundle.'\n",
+    "        git fetch \"$BUNDLE_PATH\" 'refs/heads/*:refs/heads/*'\n",
+    "    else\n",
+    "        git clone \"$BUNDLE_PATH\" .\n",
+    "    fi\n",
+    "    echo\n",
+    "    echo 'Recent history:'\n",
+    "    git log --oneline -5\n",
+    "    echo 'Repo restored.'\n",
+    "else\n",
+    "    if [ -d .git ]; then\n",
+    "        echo 'Repo already initialised.'\n",
+    "    else\n",
+    "        git init\n",
+    "        echo 'Fresh repo initialised.'\n",
+    "    fi\n",
+    "    echo 'Run Cell 5 to add game files (first run only).'\n",
+    "fi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-c5",
+   "metadata": {
+    "id": "md-c5"
+   },
+   "source": [
+    "## Cell 5 (Bash) — Copy game files, initial commit, and save bundle\n\n",
+    "**First run only. Skip on resume.**\n\n",
+    "Upload `ai.js`, `baseline_ai.js`, `game_core.js`, `evaluate.js` via the Colab\n",
+    "file browser (left sidebar, upload icon) so they appear at `/content/`. Then run this cell.\n\n",
+    "**Fix applied:** After committing the JS files this cell now calls `git bundle create`\n",
+    "to persist the repo to Drive immediately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5-files",
+   "metadata": {
+    "id": "c5-files"
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "UPLOAD_DIR='/content'\n",
+    "cd \"$WORK_DIR\"\n\n",
+    "ALL_OK=true\n",
+    "for f in ai.js baseline_ai.js game_core.js evaluate.js; do\n",
+    "    if [ -f \"$UPLOAD_DIR/$f\" ]; then\n",
+    "        cp \"$UPLOAD_DIR/$f\" \"$WORK_DIR/$f\"\n",
+    "        echo \"Copied: $f\"\n",
+    "    elif [ -f \"$WORK_DIR/$f\" ]; then\n",
+    "        echo \"Already present: $f\"\n",
+    "    else\n",
+    "        echo \"MISSING: $f -- upload it then re-run this cell\"\n",
+    "        ALL_OK=false\n",
+    "    fi\n",
+    "done\n\n",
+    "if [ \"$ALL_OK\" = true ]; then\n",
+    "    git add ai.js baseline_ai.js game_core.js evaluate.js\n",
+    "    git commit -m 'initial: game files'\n",
+    "    echo\n",
+    "    echo 'Saving bundle to Drive...'\n",
+    "    git bundle create \"$BUNDLE_PATH\" --all && echo \"Bundle saved to $BUNDLE_PATH\" || echo \"ERROR: bundle save failed\"\n",
+    "    echo\n",
+    "    echo 'Initial commit done. Proceed to Cell 6.'\n",
+    "fi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-c6",
+   "metadata": {
+    "id": "md-c6"
+   },
+   "source": [
+    "## Cell 6 (Python) — Load Qwen 2.5 3B Instruct\n\n",
+    "`Qwen/Qwen2.5-3B-Instruct` is a public, ungated model — no HuggingFace account\n",
+    "or token is required.\n\n",
+    "Downloads approximately 6 GB on first run to local Colab disk (`/content/model_cache`).\n",
+    "4-bit NF4 quantization uses approximately 4-5 GB VRAM on a T4 (16 GB total).\n\n",
+    "**Expected warning — safe to ignore:**\n",
+    "The `transformers`/`huggingface_hub` library may display a prompt about `HF_TOKEN`. This is normal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6-model",
+   "metadata": {
+    "id": "c6-model"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import torch\n",
+    "from transformers import AutoTokenizer, AutoModelForCausalLM, BitsAndBytesConfig\n\n",
+    "os.environ['PYTORCH_ALLOC_CONF'] = 'expandable_segments:True'\n\n",
+    "MODEL_ID = 'Qwen/Qwen2.5-3B-Instruct'\n\n",
+    "bnb_config = BitsAndBytesConfig(\n",
+    "    load_in_4bit=True,\n",
+    "    bnb_4bit_quant_type='nf4',\n",
+    "    bnb_4bit_compute_dtype=torch.float16,\n",
+    "    bnb_4bit_use_double_quant=True,\n",
+    ")\n\n",
+    "print(f'Loading tokenizer: {MODEL_ID}')\n",
+    "tokenizer = AutoTokenizer.from_pretrained(\n",
+    "    MODEL_ID, cache_dir=MODEL_CACHE, trust_remote_code=True\n",
+    ")\n\n",
+    "print('Loading model at 4-bit NF4...')\n",
+    "model = AutoModelForCausalLM.from_pretrained(\n",
+    "    MODEL_ID,\n",
+    "    cache_dir=MODEL_CACHE,\n",
+    "    quantization_config=bnb_config,\n",
+    "    device_map='auto',\n",
+    "    trust_remote_code=True,\n",
+    ")\n",
+    "model.eval()\n\n",
+    "print(f'Device : {next(model.parameters()).device}')\n",
+    "if torch.cuda.is_available():\n",
+    "    used  = torch.cuda.memory_allocated() / 1e9\n",
+    "    total = torch.cuda.get_device_properties(0).total_memory / 1e9\n",
+    "    print(f'VRAM   : {used:.1f} GB used / {total:.1f} GB total')\n",
+    "print('Model ready.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-c7",
+   "metadata": {
+    "id": "md-c7"
+   },
+   "source": [
+    "## Cell 7 (Python) — Define orchestrator\n\n",
+    "**This cell must be run before Cell 8.**\n\n",
+    "**Patch (crash feedback):** `run_evaluator()` now returns the error tail as a third\n",
+    "value. `build_prompt()` accepts `last_crash_error` and surfaces it at the top of\n",
+    "the prompt so the model can see what broke on the previous attempt."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7-orch",
+   "metadata": {
+    "id": "c7-orch"
+   },
+   "outputs": [],
+   "source": [
+    "import os, re, time\nfrom datetime import datetime\n\n# ── Configuration ─────────────────────────────────────────────────────────────\nTEMPERATURE      = 0.4\nMAX_EXP          = 0      # 0 = run forever; interrupt kernel to stop\nEVAL_TIMEOUT_S   = 120\nMAX_RETRIES      = 3\nMAX_HISTORY_ROWS = 30\nMAX_NEW_TOKENS   = 4096\n\nAI_FILE       = 'ai.js'\nBASELINE_FILE = 'baseline_ai.js'\nRESULTS_FILE  = 'results.tsv'\n\nREQUIRED_STRINGS = ['runAITurn', 'module.exports']\n\n\n# ── Logging ───────────────────────────────────────────────────────────────────\ndef log(msg):\n    ts = datetime.now().strftime('%H:%M:%S')\n    print(f'[{ts}] {msg}', flush=True)\n\n\n# ── File helpers ──────────────────────────────────────────────────────────────\ndef read(filename):\n    with open(os.path.join(WORK_DIR, filename), 'r', encoding='utf-8') as f:\n        return f.read()\n\ndef write(filename, content):\n    with open(os.path.join(WORK_DIR, filename), 'w', encoding='utf-8') as f:\n        f.write(content)\n\ndef append_result(commit, win_rate, eval_time, status, description):\n    wr   = f'{win_rate:.4f}'  if win_rate  is not None else '0.0000'\n    et   = f'{eval_time:.1f}' if eval_time is not None else '0.0'\n    desc = description.replace('\\\\t', ' ')[:200]\n    with open(os.path.join(WORK_DIR, RESULTS_FILE), 'a', encoding='utf-8') as f:\n        f.write(f'{commit}\\\\t{wr}\\\\t{et}\\\\t{status}\\\\t{desc}\\\\n')\n\ndef recent_results(n=MAX_HISTORY_ROWS):\n    try:\n        lines = read(RESULTS_FILE).strip().splitlines()\n        header = lines[0] if lines else 'commit\\\\twin_rate\\\\teval_time_s\\\\tstatus\\\\tdescription'\n        return '\\\\n'.join([header] + lines[1:][-n:])\n    except FileNotFoundError:\n        return 'commit\\\\twin_rate\\\\teval_time_s\\\\tstatus\\\\tdescription'\n\ndef best_win_rate_from_history():\n    best = 50.0\n    try:\n        for line in read(RESULTS_FILE).strip().splitlines()[1:]:\n            parts = line.split('\\\\t')\n            if len(parts) >= 4 and parts[3].strip().lower() == 'keep':\n                try:\n                    wr = float(parts[1])\n                    if wr > best: best = wr\n                except ValueError:\n                    pass\n    except FileNotFoundError:\n        pass\n    return best\n\n\n# ── Git helpers ───────────────────────────────────────────────────────────────\ndef git_short_hash():\n    try:\n        head = read('.git/HEAD').strip()\n        if head.startswith('ref: '):\n            return read('.git/' + head[5:]).strip()[:7]\n        return head[:7]\n    except Exception:\n        return 'unknown'\n\ndef git_commit(message):\n    safe = message.replace('\"', \"'\").replace('\\\\n', ' ')[:120]\n    os.system('git add ai.js')\n    rc = os.system(f'git commit -m \"{safe}\"') >> 8\n    return rc == 0\n\ndef git_reset_hard():\n    os.system('git reset --hard HEAD~1')\n\ndef recent_git_log(n=10):\n    try:\n        lines = read('.git/logs/HEAD').strip().splitlines()\n        log_lines = []\n        for line in reversed(lines[-n:]):\n            parts = line.split('\\\\t', 1)\n            if len(parts) == 2:\n                meta = parts[0].split()\n                if len(meta) >= 2:\n                    log_lines.append(f\"{meta[1][:7]} {parts[1]}\")\n        return '\\\\n'.join(log_lines) or '(no git history yet)'\n    except Exception:\n        return '(no git history yet)'\n\ndef save_bundle():\n    rc = os.system(f'git bundle create \"{BUNDLE_PATH}\" --all') >> 8\n    if rc == 0:\n        log(f'  [drive] Bundle saved to {BUNDLE_PATH}')\n    else:\n        log('  [drive] Bundle save failed.')\n\n\n# ── Evaluator ─────────────────────────────────────────────────────────────────\n# Returns (win_rate, eval_time, error_tail).\n# error_tail is None on success; the last 20 lines of eval_out.log on crash.\ndef run_evaluator():\n    js_wrapper = (\\n        \"const fs = require('fs');\\\\n\"\\n        \"const logFile = 'eval_out.log';\\\\n\"\\n        \"fs.writeFileSync(logFile, '');\\\\n\"\\n        \"const writeLog = (msg) => fs.appendFileSync(logFile, msg);\\\\n\"\\n        \"process.stdout.write = writeLog;\\\\n\"\\n        \"process.stderr.write = writeLog;\\\\n\"\\n        \"console.log = (...args) => writeLog(args.join(' ') + '\\\\\\\\\\\\\\\\n');\\\\n\"\\n        \"console.error = (...args) => writeLog(args.join(' ') + '\\\\\\\\\\\\\\\\n');\\\\n\"\\n        \"setTimeout(() => {\\\\n\"\\n        f\"    writeLog('\\\\\\\\\\\\\\\\n[eval] TIMEOUT after {EVAL_TIMEOUT_S}s\\\\\\\\\\\\\\\\n');\\\\n\"\\n        \"    process.exit(124);\\\\n\"\\n        f\"}}, {EVAL_TIMEOUT_S} * 1000);\\\\n\"\\n        \"try {\\\\n\"\\n        \"    require('./evaluate.js');\\\\n\"\\n        \"} catch(e) {\\\\n\"\\n        \"    writeLog('\\\\\\\\\\\\\\\\n' + (e.stack || String(e)) + '\\\\\\\\\\\\\\\\n');\\\\n\"\\n        \"    process.exit(1);\\\\n\"\\n        \"}\\\\n\"\\n    )\n\n    write('runner.js', js_wrapper)\n    os.system('node runner.js')\n\n    try:\n        out = read('eval_out.log')\n    except FileNotFoundError:\n        out = ''\n\n    wr = re.search(r'^win_rate:\\\\s+([\\\\d.]+)', out, re.MULTILINE)\n    et = re.search(r'^eval_time_s:\\\\s+([\\\\d.]+)', out, re.MULTILINE)\n\n    if not wr:\n        tail = '\\\\n'.join(out.splitlines()[-20:])\n        log('  [eval] No win_rate in output. Tail:\\\\n' + tail)\n        return None, None, tail\n\n    return float(wr.group(1)), float(et.group(1)) if et else 0.0, None\n\n\n# ── Local inference ───────────────────────────────────────────────────────────\ndef call_local(prompt):\n    messages = [\\n        {\\n            'role': 'system',\\n            'content': (\\n                'You are an expert game AI engineer. '\\n                'You reason carefully, make one focused change at a time, '\\n                'and always follow the output format exactly.'\\n            )\\n        },\\n        {'role': 'user', 'content': prompt},\\n    ]\n    text   = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)\n    inputs = tokenizer([text], return_tensors='pt').to(model.device)\n    with torch.no_grad():\n        output_ids = model.generate(\\n            **inputs,\\n            max_new_tokens=MAX_NEW_TOKENS,\\n            temperature=TEMPERATURE,\\n            do_sample=True,\\n            pad_token_id=tokenizer.eos_token_id,\\n        )\n    new_ids = output_ids[0][inputs['input_ids'].shape[1]:]\n    return tokenizer.decode(new_ids, skip_special_tokens=True)\n\n\n# ── Prompt ────────────────────────────────────────────────────────────────────\nGAME_CONSTANTS_SUMMARY = \"\"\"\n## Game constants (read-only, from game_core.js)\n\nUnit stats:  type         hp  move  capture  ranged  range\n             infantry     10    3     yes      no      -\n             mech         12    2     yes      no      -\n             tank         10    2     no       no      -\n             heavy        16    2     no       no      -\n             artillery     8    2     no       yes    3-4\n             rocket         7    2     no       yes    3-5\n\nDamage table (attacker rows, defender cols):\n             vs:  inf  tank  mech  heavy  arty  rocket\n  infantry         5    2     3     2      4     3\n  tank             8    6     5     4      5     6\n  mech             6    5     5     3      6     5\n  heavy           10    8     9     6      7     8\n  artillery        9    8     8     6      5     7\n  rocket           6   10     9     8      6     5\n\nTerrain defense multiplier (lower = more damage taken):\n  plain:0.85  wood:0.70  mountain:0.40  road:1.00  water:impassable\n\nUNIT_VALUE: infantry:10  mech:30  tank:70  heavy:160  artillery:60  rocket:150\n\nCombat: finalDamage = floor(baseDamage * (attacker.hp/maxHp) * terrainDef * (1-homeBonus))\nMelee only: defender counter-attacks if alive.  Ranged: no counter.\nCapture: capturer must stand on enemy HQ each turn; 2-10 capture points/turn.\nWin: capture all enemy HQs, or eliminate all enemy units.\n\"\"\"\n\ndef build_prompt(ai_js, results_history, experiment_num, best_wr, last_crash_error=None):\n    crash_section = (\\n        f\"## PREVIOUS ATTEMPT CRASHED -- your output produced a syntax error.\\\\\\\\n\"\\n        f\"Do NOT reproduce the same code. The error was:\\\\\\\\n\"\\n        f\"```\\\\\\\\n{{last_crash_error}}\\\\\\\\n```\\\\\\\\n\\\\\\\\n\"\\n    ) if last_crash_error else \"\"\n\n    return f\"\"\"{{crash_section}}You are an autonomous AI researcher. Your job is to improve the game AI\nin ai.js for a turn-based strategy game by modifying the heuristic decision logic.\n\n## Current experiment: #{{experiment_num}}\n## Best win_rate so far: {{best_wr:.4f}}  (baseline = 50.0, higher is better)\n## Evaluation: 200 games (4 scenarios x 25 x both sides). Noise ~1.5 points.\n{{GAME_CONSTANTS_SUMMARY}}\n\n## Experiment history (results.tsv -- use this to avoid repeating failures):\n{{results_history}}\n\n## Recent git commits (last 10) -- do NOT reproduce any of these changes exactly:\n{{recent_git_log()}}\n\n## Current ai.js -- the ONLY file you may modify:\n```javascript\n{{ai_js}}\n```\n\n## Your task\nMake ONE focused change to improve win_rate. Think about what has and has not\nworked in the history above. Do not repeat a change that was already discarded.\n\nGood targets:\n- UNIT_THREAT_WEIGHT or UNIT_CAUTION values at the top\n- hqPullWeight or approachWeight inside the movement sort\n- shouldDefend() threshold logic\n- calculateAttackValue() scoring terms\n- Attack priority ordering (who fires first)\n- New heuristics (retreat when hp < 30%, focus-fire, flanking bonus)\n- Removing a heuristic that may be hurting performance\n\n## Output format -- follow this EXACTLY (the parser is strict):\n1. Return the complete modified ai.js inside a single ```javascript code block.\n2. Do NOT include any text before the opening ```.\n3. After the closing ```, write exactly one line starting with the word CHANGE:\n   describing what you changed and your reasoning.\n\nExample:\n```javascript\n<complete file here>\n```\nCHANGE: Raised hqPullWeight from 4 to 10 for non-capturers because artillery and\ntanks were meandering instead of advancing toward the objective.\n\"\"\"\n\n\n# ── Response parsing ──────────────────────────────────────────────────────────\ndef extract_js(text):\n    m = re.search(r'```javascript\\\\s*\\\\n(.*?)```', text, re.DOTALL)\n    if m: return m.group(1)\n    m = re.search(r'```\\\\s*\\\\n(.*?)```', text, re.DOTALL)\n    if m: return m.group(1)\n    stripped = text.strip()\n    if stripped.startswith((\"'use strict'\", '\"use strict\"', '//', '/*')):\n        return stripped\n    return None\n\ndef extract_description(text):\n    after_code = re.sub(r'```.*?```', '', text, flags=re.DOTALL).strip()\n    m = re.search(r'^CHANGE:\\\\s*(.+)', after_code, re.MULTILINE | re.IGNORECASE)\n    if m: return m.group(1).strip()[:200]\n    for line in after_code.splitlines():\\n        line = line.strip()\\n        if line and not line.startswith('`'):\\n            return line[:200]\n    return 'no description provided'\n\ndef passes_sanity_check(code):\n    for s in REQUIRED_STRINGS:\\n        if s not in code:\\n            return False, f'missing required string: {{s}}'\n    if len(code) < 500:    return False, f'too short ({{len(code)}} chars)'\n    if len(code) > 80_000: return False, f'too long ({{len(code)}} chars)'\n    return True, 'ok'\n\n\nprint('Orchestrator defined. Run Cell 8 to start.')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-two-loops",
+   "metadata": {
+    "id": "md-two-loops"
+   },
+   "source": [
+    "## Research Architecture — Two Complementary Loops\n\n",
+    "### Loop 1 — Autoresearch (this notebook)\n\n",
+    "Operates continuously without human intervention. The model makes small, focused changes to `ai.js` guided solely by win rate. Its strengths are parametric optimisation and simple heuristic additions. Its limitation is that it cannot diagnose systemic problems or produce substantial algorithmic additions reliably.\n\n",
+    "### Loop 2 — Directed Research (session-based, human-guided)\n\n",
+    "Operates through human observation and chat-based analysis. Known gameplay problems are described in natural language and reasoned about with reference to the game constants, damage tables, and code structure. Output is injected into `ai.js` manually before resuming the autoresearch loop.\n\n",
+    "### Division of Labour\n\n",
+    "| Class of change | Loop 1 | Loop 2 |\n",
+    "|---|---|---|\n",
+    "| Parameter tuning | Yes | No |\n",
+    "| Simple heuristic additions | Occasionally | Yes |\n",
+    "| Emergent behavioural correction | Yes | No |\n",
+    "| Targeted fix for a known problem | No | Yes |\n",
+    "| Substantial algorithmic additions | No | Yes |\n\n",
+    "### Injecting a Loop 2 change\n\n",
+    "1. Interrupt Cell 8 if running.\n",
+    "2. Edit `ai.js` in `/content/gridcombat/` directly.\n",
+    "3. Commit: `git add ai.js && git commit -m 'directed: description'`\n",
+    "4. Save bundle: `git bundle create \"$BUNDLE_PATH\" --all`\n",
+    "5. Resume Cell 8."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-c8",
+   "metadata": {
+    "id": "md-c8"
+   },
+   "source": [
+    "## Cell 8 (Python) — Run the experiment loop\n\n",
+    "Stop at any time with **Runtime > Interrupt execution**.\n",
+    "Bundle is saved to Drive on every KEEP.\n",
+    "On session restart re-run cells 1, 2, 3, 4, 6, 7, then this cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8-run",
+   "metadata": {
+    "id": "c8-run"
+   },
+   "outputs": [],
+   "source": [
+    "import os\nos.chdir(WORK_DIR)\n\nfor f in [AI_FILE, BASELINE_FILE]:\\n    if not os.path.exists(os.path.join(WORK_DIR, f)):\\n        raise FileNotFoundError(f'{{f}} not found in {{WORK_DIR}}. Run Cell 5 first.')\n\nif not os.path.exists(os.path.join(WORK_DIR, RESULTS_FILE)):\\n    write(RESULTS_FILE, 'commit\\\\twin_rate\\\\teval_time_s\\\\tstatus\\\\tdescription\\\\n')\n\nlog(f'Model           : Qwen2.5-3B-Instruct (local, 4-bit NF4)')\nlog(f'Temperature     : {{TEMPERATURE}}')\nlog(f'Max experiments : {{\\\"inf\\\" if MAX_EXP == 0 else MAX_EXP}}')\nlog(f'Eval timeout    : {{EVAL_TIMEOUT_S}}s')\nlog(f'Work dir        : {{WORK_DIR}}')\nlog(f'Drive bundle    : {{BUNDLE_PATH}}')\nlog('')\n\nbest_wr              = best_win_rate_from_history()\nexperiment_num       = 0\nconsecutive_failures = 0\nlast_crash_error     = None\nlog(f'Best win_rate from history: {{best_wr:.4f}}')\n\nwhile True:\\n    experiment_num += 1\\n    if MAX_EXP > 0 and experiment_num > MAX_EXP:\\n        log(f'Reached MAX_EXPERIMENTS={{MAX_EXP}}. Stopping.')\\n        break\\n\\n    log('')\\n    log('=' * 60)\\n    log(f'  MAX_NEW_TOKENS  : {{MAX_NEW_TOKENS}}')\\n    log(f'Experiment #{{experiment_num}}  |  Best: {{best_wr:.4f}}')\\n    log('=' * 60)\\n\\n    # ---- Inference ----\\n    ai_js  = read(AI_FILE)\\n    prompt = build_prompt(ai_js, recent_results(), experiment_num, best_wr, last_crash_error)\\n    log('Running local inference...')\\n    try:\\n        response_text        = call_local(prompt)\\n        consecutive_failures = 0\\n        last_crash_error     = None\\n    except Exception as e:\\n        log(f'Inference error: {{e}}')\\n        consecutive_failures += 1\\n        if consecutive_failures >= MAX_RETRIES:\\n            log('Too many consecutive failures. Stopping.')\\n            break\\n        experiment_num -= 1\\n        time.sleep(2)\\n        continue\\n\\n    # ---- Parse ----\\n    new_code    = extract_js(response_text)\\n    description = extract_description(response_text)\\n\\n    if new_code is None:\\n        log('Could not extract JS. Skipping.')\\n        log('Preview: ' + response_text[:400].replace('\\\\n', ' '))\\n        experiment_num -= 1\\n        continue\\n\\n    ok, reason = passes_sanity_check(new_code)\\n    if not ok:\\n        log(f'Sanity check failed: {{reason}}. Skipping.')\\n        experiment_num -= 1\\n        continue\\n\\n    log(f'Proposed: {{description}}')\\n\\n    # ---- Commit ----\\n    write(AI_FILE, new_code)\\n    if not git_commit(description):\\n        log('git commit failed (nothing changed). Restoring.')\\n        os.system('git checkout HEAD -- ai.js')\\n        experiment_num -= 1\\n        continue\\n\\n    commit_hash = git_short_hash()\\n    log(f'Committed {{commit_hash}}')\\n\\n    # ---- Evaluate ----\\n    log('Running evaluator...')\\n    win_rate, eval_time, crash_error = run_evaluator()\\n\\n    if win_rate is None:\\n        log('CRASH -- evaluator returned no win_rate. Reverting.')\\n        git_reset_hard()\\n        append_result(commit_hash, None, None, 'crash', description)\\n        last_crash_error = crash_error\\n        continue\\n\\n    delta = win_rate - best_wr\\n    log(f'win_rate: {{win_rate:.4f}}  ({{delta:+.4f}} vs best)  eval_time: {{eval_time:.1f}s')\\n\\n    # ---- Keep or discard ----\\n    if win_rate > best_wr:\\n        best_wr = win_rate\\n        log(f'KEEP -- new best: {{best_wr:.4f}}')\\n        append_result(commit_hash, win_rate, eval_time, 'keep', description)\\n        save_bundle()\\n    else:\\n        git_reset_hard()\\n        log('DISCARD -- reverted to previous best.')\\n        append_result(commit_hash, win_rate, eval_time, 'discard', description)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-findings",
+   "metadata": {
+    "id": "md-findings"
+   },
+   "source": [
+    "## Findings, Conclusions, and Future Directions\n\n",
+    "### What Was Established\n\n",
+    "The autoresearch loop functions correctly. A win rate improvement of 11.75 points was achieved in the first successful experiment. The Qwen 2.5 3B model at 4-bit NF4 is the correct instrument for this loop on a T4 GPU.\n\n",
+    "### What Was Refuted\n\n",
+    "The 3B model is an insufficient agent for sustained autonomous code modification. It produces valid output under ideal conditions but fails consistently across iterations — repeating proposals, producing syntax errors, and omitting required functions. Seven consecutive crashes at line 91 with identical proposals confirm the model is fixating rather than exploring. This is a capacity problem, not a harness or problem with the prompt.\n\n",
+    "### Future Directions\n\n",
+    "**Direction 3 — A more capable small model.** As the Qwen family and others advance, a future 3B or 4B model with stronger instruction-following and code generation capability may resolve the agent reliability problem without exceeding the T4 constraints. This requires only a model ID update in Cell 6.\n\n",
+    "### The Unresolved Question\n\n",
+    "Whether AI versus AI win rate improvements translate to harder human play remains the final criterion of practical success. The sole measure of value for this project is whether the game becomes harder to defeat for a human player."
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
This update enhances the project's documentation by providing more detailed information about the included games (Chess, Chess v1-LLM, Boxes, and Grid Combat) and their relevance to reinforcement learning. It specifically introduces the "Autoresearch" system for Grid Combat, providing both a descriptive Markdown file and the corresponding Jupyter Notebook for use in Google Colab. The main README's Mermaid diagram has been fixed for correct rendering.

---
*PR created automatically by Jules for task [6491000188751656154](https://jules.google.com/task/6491000188751656154) started by @bob-friedman*