### PR TITLE
Update Autoresearch documentation, notebook, and contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,4 +303,5 @@ The game logic for Grid Combat is contained in `grid-combat/game.js`. The follow
 The development of the software and code benefited significantly from discussions and iterative refinement with AI language models. The author oversaw and reviewed the accuracy and robustness of all parts of its development.
 
 -   **Gemini 2.5 Pro** (Google) — primary development of the game collection and RL data retrieval interfaces.
+-   **Gemini 3.1 Pro** (Google) — transition to Google Flash Lite in the Autoresearch workflow script and several bug fixes.
 -   **Claude Sonnet** (Anthropic) — design and implementation of the Grid Combat Autoresearch system, including the two-loop architecture, experiment harness, evaluator, git persistence strategy, and formal documentation of findings.

--- a/autoresearch/GridCombat_Autoresearch.ipynb
+++ b/autoresearch/GridCombat_Autoresearch.ipynb
@@ -1054,7 +1054,7 @@
         "\n",
         "### The Two-Loop Strategy\n",
         "\n",
-        "The autoresearch loop above operates within a narrow band of possible improvements. It adjusts parameters and simple heuristics \u2014 weights, thresholds, priority orderings \u2014 guided by the win rate signal. Benefical emergent effects are possible, but deliberate algorithmic reasoning is best handled by the second loop.\n",
+        "The autoresearch loop above operates within a narrow band of possible improvements. It adjusts parameters and simple heuristics \u2014 weights, thresholds, priority orderings \u2014 guided by the win rate signal. Beneficial emergent effects are possible, but deliberate algorithmic reasoning is best handled by the second loop.\n",
         "\n",
         "A second, complementary loop is human-guided and driven by observation. Known gameplay problems are described and reasoned about, producing targeted algorithmic additions. These are injected into `ai.js` manually, and the autoresearch loop then fine-tunes the parameters within that expanded capability.\n",
         "\n",


### PR DESCRIPTION
- Added Gemini 3.1 Pro to the Contributors section in `README.md` for its role in the model transition and script bug fixes.
- Fixed a typo in the notebook documentation.