### PR TITLE
Update Autoresearch Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Each skirmish is a core force (2 Infantry, 1 Mech, 2 Tanks) plus randomized supp
 
 This section documents an autonomous research system developed for iterative improvement of the Grid Combat AI heuristic (`ai.js`). The architecture and procedure are based on the [autoresearch](https://github.com/karpathy/autoresearch) project by Andrej Karpathy. It is released as open scientific work for researchers aiming to automate the discovery of optimal game heuristics.
 
-A closed loop runs on Google Colab, leveraging Gemini 2.5 Flash-Lite (via API) or a local Qwen 2.5 3B model (T4 GPU). The language model proposes modifications to `ai.js`; a Node.js evaluator measures win rate across 200 games; the harness commits, evaluates, and keeps or reverts each change without human intervention. All progress is persisted to Google Drive via a git bundle, surviving session expiry.
+A closed loop runs on Google Colab, leveraging Gemini 2.5 Flash-Lite (via API) or a local Qwen 2.5 3B model (T4 GPU). The language model proposes modifications to `ai.js`; a Node.js evaluator measures win rate across 400 games; the harness backups, evaluates, and keeps or reverts each change without human intervention. All progress is persisted to Google Drive via a zip archive, surviving session expiry.
 
 The system implements two complementary loops. Loop 1 runs autonomously and is suited to parameter tuning and simple heuristic additions. Loop 2 is human-guided and addresses targeted algorithmic changes — for example, correcting ranged unit positioning — that win rate alone cannot diagnose. A Loop 2 change is injected into `ai.js` manually, then Loop 1 resumes and fine-tunes within the expanded capability.
 
@@ -182,15 +182,15 @@ flowchart TD
         D -- "no JS found" --> B
         D -- "JS extracted" --> E{Sanity<br/>check}
         E -- fail --> B
-        E -- pass --> F[git commit ai.js]
-        F --> G["Evaluate<br/>200 games · Node.js"]
+        E -- pass --> F[backup ai.js<br/>log change]
+        F --> G["Evaluate<br/>400 games · Node.js"]
         G --> H{"win_rate<br/>returned?"}
-        H -- crash --> I["Revert<br/>git reset --hard<br/>store error tail"]
+        H -- crash --> I["Revert<br/>restore from backup<br/>store error tail"]
         I --> B
         H -- yes --> J{"win_rate<br/>> best?"}
-        J -- no --> K["Discard<br/>git reset --hard"]
+        J -- no --> K["Discard<br/>restore from backup"]
         K --> B
-        J -- yes --> L["Keep<br/>update best<br/>save bundle to Drive"]
+        J -- yes --> L["Keep<br/>update best<br/>save zip to Drive"]
         L --> B
     end
 
@@ -198,7 +198,7 @@ flowchart TD
         M["Observe gameplay<br/>identify failure mode"]
         M --> N["Reason with game constants<br/>damage tables · code structure"]
         N --> O["Write targeted change<br/>to ai.js"]
-        O --> P[git commit<br/>git bundle save]
+        O --> P[log change<br/>save zip to Drive]
     end
 
     P -- "inject & resume" --> A
@@ -209,28 +209,31 @@ flowchart TD
 | Metric | Value |
 | :--- | :--- |
 | Baseline win rate | 50.0% |
-| Best achieved | 61.75% (Experiment #1) |
-| Gain | +11.75 points |
-| Evaluator | 200 games · 4 scenarios · noise ≈ 1.5 pts |
+| Best achieved | 62.5% |
+| Gain | +12.5 points |
+| Evaluator | 400 games · 4 scenarios · noise ≈ 0.7 pts |
 | Primary Model | Gemini 2.5 Flash-Lite (API) |
 | Fallback Model | Qwen 2.5 3B · 4-bit NF4 (local) |
 | Platform | Google Colab |
 
 #### Findings
 
-**Established.** The autoresearch loop functions correctly and reliably, especially when using Gemini 2.5 Flash-Lite. It handles inference, evaluation, and persistence without human intervention. Significant win rate improvements have been achieved, confirming the pipeline produces real results.
+**Established.** The autoresearch loop functions correctly and reliably, especially when using Gemini 2.5 Flash-Lite. It handles inference, evaluation, and persistence without human intervention. Win rate improvements of 12.5 points have been achieved, confirming the pipeline produces real results.
 
-**Refining Local Constraints.** Earlier experiments with Qwen 2.5 3B demonstrated that while 3B-class models can achieve initial gains, they eventually hit a capacity ceiling in agentic use. The transition to Gemini 2.5 Flash-Lite successfully bypassed these limitations, allowing for sustained, autonomous exploration of the heuristic search space without the syntactic degradation often observed in smaller local models.
+**Refining Local Constraints.** Earlier experiments with Qwen 2.5 3B demonstrated that while 3B-class models can achieve initial gains, they eventually hit a capacity ceiling in agentic use. The transition to Gemini 2.5 Flash-Lite successfully bypassed these limitations, allowing for sustained, autonomous exploration of the heuristic search space.
 
-**Open question.** Whether the win rate gain translates to harder human play is untested and is the sole criterion of practical success for this project.
+**MCTS Re-Rooting.** The system identifies win rate plateaus (e.g., 8 consecutive experiments without improvement) as a signal of an exhausted subtree in its Monte Carlo Tree Search framework. Progress is continued through a "re-rooting" protocol: the best candidate is promoted to the new baseline, and the search history is reset.
 
 #### Future Direction
 
-Future research will focus on human play testing to verify win rate gains, and implementing more complex spatial awareness heuristics for ranged units that the autoresearch loop can then parameterise.
+Future research will focus on human play testing to verify win rate gains, implementing more complex spatial awareness heuristics, and providing richer game logs to the model to narrow the search toward productive changes.
 
 #### Reproducing This System
 
-Requirements: Google Colab account. Gemini API key (recommended) or T4 GPU runtime. The notebook `GridCombat_Autoresearch.ipynb` contains all cells, configuration, and documentation. Upload `ai.js`, `baseline_ai.js`, `game_core.js`, and `evaluate.js` to Colab, then run cells in order. The git bundle on Drive preserves all progress across sessions.
+Requirements: Google Colab account. Gemini API key (recommended) or T4 GPU runtime. The notebook `GridCombat_Autoresearch.ipynb` contains all cells, configuration, and documentation. Upload `ai.js`, `baseline_ai.js`, `game_core.js`, and `evaluate.js` to Colab, then run cells in order. The zip archive on Drive preserves all progress across sessions.
+
+> [!NOTE]
+> The `GridCombat_Autoresearch.ipynb` file may not be displayed correctly by the GitHub Markdown viewer. For an accurate view of the notebook's content, please use the **RAW** mode or open it directly in Google Colab.
 
 ___
 ## Othello

--- a/autoresearch/README.md
+++ b/autoresearch/README.md
@@ -1,0 +1,23 @@
+# Grid Combat Autoresearch
+
+This directory contains the implementation and documentation for an autonomous research system designed to improve the AI of the strategic game **Grid Combat**.
+
+## Overview
+
+The Autoresearch project implements a "Generalised Two-Loop MCTS Pipeline" for optimizing game heuristics. It leverages Large Language Models (LLMs) to propose and evaluate changes to the AI logic, iteratively improving its performance without human intervention.
+
+For full details on the project architecture, empirical results, and findings, please refer to the **[Autoresearch section in the main README.md](../README.md#autoresearch--autonomous-ai-improvement)**.
+
+## Contents
+
+-   **`GridCombat_Autoresearch.ipynb`**: The primary implementation of the research loop, designed to run in Google Colab. It handles the inference, evaluation, and persistence of the research experiments.
+-   **`AUTORESEARCH.md`**: Documents the theoretical framework and the generalized two-loop architecture used by this system.
+-   **`ai.js`**: The current best version of the Grid Combat AI heuristic.
+-   **`baseline_ai.js`**: The baseline AI used for comparison during experiments.
+-   **`evaluate.js`**: The Node.js-based evaluation script that measures the win rate of the candidate AI against the baseline across 400 games.
+-   **`game_core.js`**: The core game logic and constants shared by the AI and the evaluator.
+
+## Note on Notebook Display
+
+> [!NOTE]
+> The `GridCombat_Autoresearch.ipynb` file may not be displayed correctly by the GitHub Markdown viewer due to its size and format. For an accurate view of the notebook's content, including all instructions and results, please use the **RAW** mode or open it directly in Google Colab.


### PR DESCRIPTION
This update synchronizes the repository's documentation with the latest improvements made to the Grid Combat Autoresearch system. Key changes include:

1.  **Main README.md (Autoresearch Section):**
    *   Updated the evaluation trial count from 200 to 400 games.
    *   Updated empirical results to show the latest peak win rate of 62.5% and a reduced noise floor of ~0.7 points.
    *   Revised the Mermaid flowchart to accurately reflect the current backup/zip-archive persistence strategy (replacing the previous git-based workflow).
    *   Integrated findings regarding the "MCTS Re-Rooting" protocol and win rate plateaus.
    *   Added a warning about GitHub's Markdown rendering limitations for `.ipynb` files, recommending "RAW" mode.

2.  **New autoresearch/README.md:**
    *   Provides a dedicated entry point for the `autoresearch/` directory.
    *   Explains the roles of `AUTORESEARCH.md` (theoretical framework) and `GridCombat_Autoresearch.ipynb` (implementation).
    *   Establishes clear links back to the comprehensive documentation in the root README.
    *   Reiterates the note on notebook display for visibility within the directory.

These changes ensure that researchers and contributors have accurate, up-to-date information about the autonomous AI research pipeline.

---
*PR created automatically by Jules for task [11726614860725439180](https://jules.google.com/task/11726614860725439180) started by @bob-friedman*