### PR TITLE
Add Sparsity Resolution document and reorganize autoresearch docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,38 +171,7 @@ This section documents an autonomous research system developed for iterative imp
 
 A closed loop runs on Google Colab, leveraging Gemini 2.5 Flash-Lite (via API) or a local Qwen 2.5 3B model (T4 GPU). The language model proposes modifications to `ai.js`; a Node.js evaluator measures win rate across 400 games; the harness backups, evaluates, and keeps or reverts each change without human intervention. All progress is persisted to Google Drive via a zip archive, surviving session expiry.
 
-The system implements two complementary loops. Loop 1 runs autonomously and is suited to parameter tuning and simple heuristic additions. Loop 2 is human-guided and addresses targeted algorithmic changes — for example, correcting ranged unit positioning — that win rate alone cannot diagnose. A Loop 2 change is injected into `ai.js` manually, then Loop 1 resumes and fine-tunes within the expanded capability.
-
-```mermaid
-flowchart TD
-    subgraph L1["Loop 1 — Autoresearch (continuous)"]
-        A([Start / Resume]) --> B[Read ai.js<br/>+ build prompt]
-        B --> C["Inference<br/>Gemini 2.5 Flash-Lite<br/>or Qwen 2.5 3B"]
-        C --> D{Parse<br/>response}
-        D -- "no JS found" --> B
-        D -- "JS extracted" --> E{Sanity<br/>check}
-        E -- fail --> B
-        E -- pass --> F[backup ai.js<br/>log change]
-        F --> G["Evaluate<br/>400 games · Node.js"]
-        G --> H{"win_rate<br/>returned?"}
-        H -- crash --> I["Revert<br/>restore from backup<br/>store error tail"]
-        I --> B
-        H -- yes --> J{"win_rate<br/>> best?"}
-        J -- no --> K["Discard<br/>restore from backup"]
-        K --> B
-        J -- yes --> L["Keep<br/>update best<br/>save zip to Drive"]
-        L --> B
-    end
-
-    subgraph L2["Loop 2 — Directed Research (human-guided)"]
-        M["Observe gameplay<br/>identify failure mode"]
-        M --> N["Reason with game constants<br/>damage tables · code structure"]
-        N --> O["Write targeted change<br/>to ai.js"]
-        O --> P[log change<br/>save zip to Drive]
-    end
-
-    P -- "inject & resume" --> A
-```
+The system implements two complementary loops. Loop 1 runs autonomously and is suited to parameter tuning and simple heuristic additions. Loop 2 is human-guided and addresses targeted algorithmic changes — for example, correcting ranged unit positioning — that win rate alone cannot diagnose. A Loop 2 change is injected into `ai.js` manually, then Loop 1 resumes and fine-tunes within the expanded capability. For more information, see the [Sparsity Resolution](autoresearch/SPARSITY_RESOLUTION.md) research document.
 
 #### Empirical Results
 

--- a/autoresearch/README.md
+++ b/autoresearch/README.md
@@ -8,10 +8,42 @@ The Autoresearch project implements a "Generalised Two-Loop MCTS Pipeline" for o
 
 For full details on the project architecture, empirical results, and findings, please refer to the **[Autoresearch section in the main README.md](../README.md#autoresearch--autonomous-ai-improvement)**.
 
+```mermaid
+flowchart TD
+    subgraph L1["Loop 1 — Autoresearch (continuous)"]
+        A([Start / Resume]) --> B[Read ai.js<br/>+ build prompt]
+        B --> C["Inference<br/>Gemini 2.5 Flash-Lite<br/>or Qwen 2.5 3B"]
+        C --> D{Parse<br/>response}
+        D -- "no JS found" --> B
+        D -- "JS extracted" --> E{Sanity<br/>check}
+        E -- fail --> B
+        E -- pass --> F[backup ai.js<br/>log change]
+        F --> G["Evaluate<br/>400 games · Node.js"]
+        G --> H{"win_rate<br/>returned?"}
+        H -- crash --> I["Revert<br/>restore from backup<br/>store error tail"]
+        I --> B
+        H -- yes --> J{"win_rate<br/>> best?"}
+        J -- no --> K["Discard<br/>restore from backup"]
+        K --> B
+        J -- yes --> L["Keep<br/>update best<br/>save zip to Drive"]
+        L --> B
+    end
+
+    subgraph L2["Loop 2 — Directed Research (human-guided)"]
+        M["Observe gameplay<br/>identify failure mode"]
+        M --> N["Reason with game constants<br/>damage tables · code structure"]
+        N --> O["Write targeted change<br/>to ai.js"]
+        O --> P[log change<br/>save zip to Drive]
+    end
+
+    P -- "inject & resume" --> A
+```
+
 ## Contents
 
 -   **`GridCombat_Autoresearch.ipynb`**: The primary implementation of the research loop, designed to run in Google Colab. It handles the inference, evaluation, and persistence of the research experiments.
 -   **`AUTORESEARCH.md`**: Documents the theoretical framework and the generalized two-loop architecture used by this system.
+-   **`SPARSITY_RESOLUTION.md`**: Research document exploring the resolution of semantic sparsity in natural language processing through heuristic smoothing, manifolds, and Mixture of Experts (MoE) architectures.
 -   **`ai.js`**: The current best version of the Grid Combat AI heuristic.
 -   **`baseline_ai.js`**: The baseline AI used for comparison during experiments.
 -   **`evaluate.js`**: The Node.js-based evaluation script that measures the win rate of the candidate AI against the baseline across 400 games.

--- a/autoresearch/SPARSITY_RESOLUTION.md
+++ b/autoresearch/SPARSITY_RESOLUTION.md
@@ -1,0 +1,172 @@
+# The Sparsity Resolution: From Heuristic Smoothing and Semantic Manifolds to Architectural Mixture of Experts in Natural Language Processing
+
+## The Combinatorial Empty Space and the Symbolic Barrier
+
+The core challenge of processing human language with classical computational systems is rooted in information theory and data representation. If intelligence is conceptualized as the capacity to extract patterns to compress data, the sparsity problem represents the primary structural barrier to this compression. In a purely symbolic representation of language, words are treated as discrete, orthogonal entities. This discrete categorization yields a combinatorial explosion when modeling sequences of words.
+
+To conceptualize the scale of this problem, one can envision a multidimensional spreadsheet representing every possible three-word combination (trigram) in the English language. In a language with a vocabulary ($V$) of approximately $100,000$ unique words, the spreadsheet of all three-word sequences contains $10^{15}$ individual cells. Under empirical conditions, a tiny fraction of these cells are occupied by conventional phrases such as "I love you" or "How are you". However, more than $99.999\%$ of the spreadsheet remains entirely empty, representing nonsensical or unobserved sequences such as "Banana concrete sadness" or "Eiffel Tower microchip".
+
+```
+Symbolic Representation (Discrete & Sparse):
+[ "giraffe" ] -> [ 0, 0, 1, 0, 0 ] <-- Orthogonal vectors (No semantic relationship)
+[ "horse" ] -> [ 0, 0, 0, 0, 1 ]
+[ "sadness" ] -> [ 1, 0, 0, 0, 0 ]
+
+Vector Embedding Space (Continuous & Dense):
+^ (Abstract Semantic Axis Y)
+|
+| * "giraffe"
+| * "elephant"
+| * "horse"
++----------------------------> (Abstract Semantic Axis X)
+```
+
+This structural empty space invalidates deterministic, count-based computational systems. When a classical computer, relying strictly on the memorization of historical word combinations, is presented with a novel sequence such as "The purple giraffe danced on the...", it attempts to query its historical database. Because the exact sequence has never been previously recorded, the computer encounters a cell of zero frequency, yielding a probability of zero for the entire sequence. Lacking any capacity for generalization, the machine freezes at this wall of sparsity, unable to predict the next token.
+
+Modern artificial intelligence and biological neural architectures resolve this combinatorial bottleneck by mapping discrete symbols into a continuous, high-dimensional vector space. Within this continuous embedding space, words are transformed from isolated, orthogonal axes into dense vectors situated on a continuous conceptual map. Geometric proximity in this latent space corresponds directly to semantic similarity. For example:
+
+*   The vector representing "giraffe" is positioned near "horse" and "elephant" along axes representing animal biology.
+*   The vector representing "danced" is aligned near "leaped" and "ran" along axes representing physical movement.
+
+Consequently, even if a neural network has never encountered the specific sequence "The purple giraffe danced on the...", it generalizes across the empty gaps of the sparse matrix. By leveraging the geometric closeness of related concepts on the manifold, the model understands that a "giraffe" behaves similarly to other large herbivores, and "dancing" implies movement near flat surfaces. It bridges the vast, empty desert of combinatorial combinations through continuous interpolation, transforming symbolic isolation into a compact map of ideas.
+
+## Statistical Mitigation of Discrete Sparsity: Absolute Discounting and Kneser-Ney Smoothing
+
+Prior to the dominance of deep neural representations, computational linguistics relied on statistical smoothing techniques to redistribute probability mass from highly frequent words to the unobserved, zero-count sequences in the long tail. The empirical foundation of word distributions is characterized by Zipf's Law, which states that the frequency of any word is inversely proportional to its rank $r$ in the frequency table. This power law, formulated by George Kingsley Zipf, reveals that while a handful of function words dominate a corpus, the vast majority of words are rare events. Interestingly, Zipf was known to harbor a disdain for mathematical formalism in linguistics, yet his empirical observations established the mathematical boundaries of language modeling.
+
+Mandelbrot extended this observation to the Zipf-Mandelbrot Law, incorporating parameters to better model the flattening of word distributions at low ranks. Mandelbrot's formulation demonstrates that random typing monkeys also produce sequences adhering to Zipfian distributions, suggesting that power laws are a fundamental property of symbolic sequence generation.
+
+To mitigate the zero-probability assignments imposed by these Zipfian tails, early researchers developed discounting techniques. Absolute Discounting subtracts a fixed constant $d$ (where $0 \leq d \leq 1$) from the count of each observed n-gram. This frees up a pool of probability mass to be allocated to unseen events. The absolute discounting bigram model is formulated as:
+
+$$P_{\text{AbsoluteDiscounting}}(w_i | w_{i-1}) = \frac{\max(C(w_{i-1}w_i) - d, 0)}{C(w_{i-1})} + \lambda(w_{i-1}) P(w_i) \quad \text{[6, 20]}$$
+
+where the normalization constant $\lambda(w_{i-1})$ represents the total discounted mass distributed proportionally to a lower-order unigram model $P(w_i)$. Church and Gale's empirical study of this phenomenon on a 22-million-word AP newswire corpus demonstrated that subtracting a constant discount from high-count bigrams yields remarkably robust estimates on held-out test data.
+
+This paradigm culminated in Kneser-Ney Smoothing, proposed in 1994 by Reinhard Kneser, Ute Essen, and Hermann Ney, and subsequently optimized by Stanley Chen and Joshua Goodman. The core innovation of Kneser-Ney is its treatment of the lower-order distribution. Rather than backing off to raw unigram probabilities, Kneser-Ney introduces continuation probability ($P_{\text{continuation}}$).
+
+Consider the proper noun bigram "San Francisco". The word "Francisco" exhibits a high unigram count solely due to its appearance after "San". In a novel context where the history is unfamiliar, a model backing off to standard unigram frequencies would erroneously assign a high probability to "Francisco". Kneser-Ney addresses this by defining $P_{\text{continuation}}$ as the ratio of unique preceding contexts a word completes, rather than its absolute frequency :
+
+$$P_{\text{continuation}}(w_i) = \frac{|\{w_{i-1} : C(w_{i-1}w_i) > 0\}|}{\sum_{w'} |\{w_{i-1} : C(w_{i-1}w') > 0\}|} \quad \text{[6, 20]}$$
+
+Under this formulation, "Francisco" has a very low continuation probability because it is preceded almost exclusively by "San". The general recursive formulation of Interpolated Kneser-Ney smoothing for an arbitrary n-gram is defined as:
+
+$$P_{\text{KN}}(w_i | w_{i-n+1}^{i-1}) = \frac{\max(c_{\text{KN}}(w_{i-n+1}^i) - d, 0)}{\sum_{v} c_{\text{KN}}(w_{i-n+1}^{i-1}v)} + \lambda(w_{i-n+1}^{i-1}) P_{\text{KN}}(w_i | w_{i-n+2}^{i-1}) \quad \text{[6]}$$
+
+The count function $c_{\text{KN}}$ adapts dynamically: it represents the empirical count for the highest-order n-gram and the continuation count for all lower-order terms. At the termination of the recursion, unigrams are interpolated with a uniform distribution over the vocabulary $V$ :
+
+$$P_{\text{KN}}(w) = \frac{\max(c_{\text{KN}}(w) - d, 0)}{\sum_{w'} c_{\text{KN}}(w')} + \lambda(\epsilon) \frac{1}{V} \quad \text{[6]}$$
+
+Unknown words ($<\text{UNK}>$) are handled as regular vocabulary entries with zero counts, mapping directly to a lambda-weighted uniform distribution. While Kneser-Ney smoothing remained the state-of-the-art language modeling technique for over fifteen years—powering commercial MapReduce translation pipelines at Google and highly optimized structures like KenLM—it was fundamentally limited by its inability to capture long-range semantic dependencies beyond its local n-gram context window.
+
+## The Geometry of Meaning: The Latent Semantic Manifold and Discretization Limits
+
+As NLP systems transitioned from discrete n-grams to deep neural architectures, researchers encountered the Curse of Dimensionality. When data is projected into high-dimensional vector spaces, the volume of the space grows exponentially, rendering points highly sparse and distant. This distance degradation complicates tasks like similarity searches, as standard Euclidean distance functions become uniform and noisy in high-dimensional settings.
+
+The Semantic Manifold Hypothesis resolves this contradiction by stating that high-dimensional word representations and dynamic hidden states do not explore the full ambient vector space $\mathbb{R}^d$. Instead, they concentrate near a smooth, low-dimensional Riemannian submanifold $\mathcal{M}$ (where the intrinsic dimension $k \ll d$) that captures the underlying semantic structure of language.
+
+While raw token embeddings at the input layer (layer 0) violate the manifold hypothesis due to their discrete symbolic origin, deeper transformer layers construct a coherent manifold through successive nonlinear transformations. Statistical testing across multiple transformer scales reveals that the intrinsic dimension of hidden states follows a universal "hourglass" or "hunchback" pattern: expanding in early layers to extract complex features, contracting to only 1% to 3% of the ambient dimension in middle layers where abstract semantic concepts are concentrated, and expanding slightly at the final layers for token projection.
+
+```
+Hourglass Intrinsic Dimension Profile:
+Layer 0 (Embeddings): High (Discrete, No Manifold Structure)
+Layer L/2 (Middle): Low (Contracted, Smooth Semantic Manifold)
+Layer L (Output): Medium (Slight Expansion for Vocabulary Projection)
+```
+
+To analyze this space, the latent manifold $\mathcal{M}$ is equipped with the Fisher Information Metric $G(h)$, which acts as a Riemannian metric derived from the model's output probability distribution. For a hidden state $h$, the Fisher metric is formulated as:
+
+$$G(h) = W^\top \Sigma_p W \quad \text{[9, 25, 26]}$$
+
+where $W \in \mathbb{R}^{V \times d}$ is the unembedding matrix, and $\Sigma_p = \text{diag}(p) - pp^\top$ is the softmax covariance of the token distribution $p$. In this geometric formulation, tokens correspond to Voronoi regions that partition the semantic manifold, and language generation becomes a measure-theoretic projection from continuous hidden states onto these discrete Voronoi cells.
+
+The boundary between these Voronoi cells represents a region of high uncertainty. For a hidden state $h$, the Voronoi margin is defined as the difference between the top two token logits :
+
+$$m(h) = \ell_{t^*}(h) - \ell_{t^{**}}(h) \quad \text{[27]}$$
+
+This margin allows researchers to define the expressibility gap $\eta(\epsilon)$, representing the fraction of semantic space where the discrete vocabulary fails to confidently resolve continuous states :
+
+$$\eta(\epsilon) = \frac{\mu(\{h \in \mathcal{M} : m(h) < \epsilon\})}{\text{vol}(\mathcal{M})} \quad \text{[27]}$$
+
+Under regularity conditions, the expressibility gap obeys a linear volume scaling law as $\epsilon \to 0^+$ :
+
+$$\eta(\epsilon) = \alpha \cdot \epsilon + \mathcal{O}(\epsilon^2) \quad \text{[27]}$$
+
+This relationship, proven via the coarea formula, indicates a persistent "hard core" of boundary-proximal states where token selection is inherently unstable. Models can be post-hoc intervened upon to maximize this margin using Fisher information distance, compressing the expressibility gap by restructuring the Voronoi tessellation without losing downstream task accuracy.
+
+| Empirical Model & Dataset | Key Architecture Specs | Evaluation Metrics | Manifold Observations |
+| :--- | :--- | :--- | :--- |
+| **Qwen3.5-4B-Base** | 4.21B text parameters, 32 layers, $d=2560$, $V=248,320$. | WikiText-103, float32 precision, 256,577 token positions. | Linear scaling of expressibility gap verified ($\text{R}^2 > 0.985$). |
+| **Fisher MRP Intervention** | Post-hoc margin maximization ($\lambda_{\text{MRP}} = 0.6$). | +28% median margin improvement, zero benchmark degradation. | Compressed expressibility gap via localized Voronoi boundary reshaping. |
+| **GPT-2 token point clouds** | Multi-layer attention, tied input/output embeddings. | Intrinsic dimension (ID) profiles across layers. | High correlation between layer-wise manifold curvature and prediction loss. |
+
+## Biological Sparse Coding and Superposition in Deep Networks
+
+The physical constraints of intelligence demand that neural systems optimize representation capacity relative to metabolic and hardware costs. In biological sensory processing, this is governed by Barlow's Efficient Coding Hypothesis and the single neuron doctrine. These theories argue that sensory pathways represent stimuli using as few active neurons as possible.
+
+Physiological studies in the primary visual cortex (V1) reveal that natural images trigger a highly sparse, overcomplete population response. This sparse coding behavior is dynamic: upon stimulus onset, the visual cortex exhibits a transient decrease in sparseness as feedforward inputs trigger a broad, redundant population activation. Over time, competitive lateral interactions governed by local inhibitory circuits refine the representation, driving metabolic consumption down while preserving high mutual information, steadily maximizing coding efficiency.
+
+```
+Temporal Sparsification in V1 Cortex:
+Stimulus Onset -> Broad Activation (Low Sparseness, High Metabolic Cost)
+Time-to-Peak -> Lateral Inhibition / LCA Refinement (High Sparseness, Stable Mutual Info)
+```
+
+To quantify this representation density, researchers analyze population sparseness across the network or lifetime selectivity across stimulus classes, leveraging metrics such as the Gini index, kurtosis, and coefficient of variation. These principles are formalized in Nonnegative Sparse Coding (NSC) and Locally Competitive Algorithms (LCA). LCA uses thresholding and lateral inhibition to converge on sparse representations under generative constraints.
+
+Artificial networks mirror this dynamic through the Superposition Hypothesis. When the number of features $M$ in the data exceeds the activation space dimensionality $N$, the network projects these features as non-orthogonal linear combinations. This enables the model to simulate more "virtual neurons" than its physical bottleneck allows. However, this compression introduces interference, which is mitigated when features are sparse and rarely co-occur. Nonlinear activation functions like ReLU and Gated architectures stabilize these representations by enforcing a privileged coordinate basis.
+
+To isolate these superimposed features for mechanistic analysis, researchers train Sparse Autoencoders (SAEs) on intermediate network activations. An SAE projects the activations into an overcomplete hidden layer of size $F \gg N$. It is regularized to reconstruct the input while minimizing active latents, typically leveraging an $\ell_1$ penalty to drive coordinates to zero :
+
+$$\mathcal{L}_{\text{SAE}} = \|z - W_d \sigma(W_e z + b_e) - b_d\|_2^2 + \beta \|\sigma(W_e z + b_e)\|_1 \quad \text{[37, 39, 43]}$$
+
+Standard vector-based SAEs, however, suffer from feature splitting. Because real-world semantic features are often multi-dimensional (intrinsic dimension $d_i \geq 2$), attempting to represent them using one-dimensional, single-vector decoder directions forces the autoencoder to fragment a single coherent concept across many near-collinear latents.
+
+To resolve this limitation, Subspace-Aware Sparse Autoencoders (SASA) replace single-vector decoders with learned decoder subspaces. By organizing latents into low-rank blocks and enforcing block sparsity via Top-$s$ group gating alongside a rank-adaptive nuclear-norm regularizer, SASA allows a single group to represent multi-dimensional feature slices.
+
+| Interpretability Metric | Standard Sparse Autoencoders (SAE) | Subspace-Aware Sparse Autoencoders (SASA) |
+| :--- | :--- | :--- |
+| **Decoder Structure** | Single-vector directions (one-dimensional). | Learned multi-dimensional decoder subspaces. |
+| **Sparsity Constraints** | $\ell_1$ penalty or Top-$k$ scalar gating. | Top-$s$ group gating with block sparsity. |
+| **Regularization Type** | Strict $\ell_1$-norm on individual activations. | Nuclear-norm rank-adaptive regularization. |
+| **Sample Complexity** | Exponentially scaled to feature dimension $d_i$. | Polynomial scaling relative to feature dimension $d_i$. |
+| **Feature Splitting** | High; fragments coherent concepts into many latents. | Low; consolidates multi-dimensional features. |
+| **Empirical Performance** | Demands extensive token budgets for reconstruction. | Matches reconstruction on half the token budget. |
+
+## Architectural Sparsity: Sparse Mixture of Experts Layers
+
+To scale artificial models beyond physical hardware constraints, deep architectures implement structural sparsity through Sparse Mixture of Experts (MoE). While traditional neural networks process all inputs through every parameter, MoE introduces conditional computation, dynamically activating specialized subnetworks on a per-token basis. This decoupled scaling model allows the total parameter footprint to expand while keeping active execution costs constant.
+
+Historically, the concept of MoE originated in 1991 with the Adaptive Mixture of Local Experts proposed by Jacobs, Jordan, Nowlan, and Hinton. Early formulations functioned as ensemble learners where a gating network performed a soft, weighted average over all expert outputs. In modern deep learning architectures, beginning with the sparsely-gated MoE layer introduced by Shazeer et al. in 2017, sparsity is achieved by routing each token to a highly restricted subset of Top-$K$ experts.
+
+In a standard MoE transformer block, the computationally heavy Feed-Forward Network (FFN) layer is replaced by an MoE block, while the self-attention layer remains shared across all paths. The routing network scores each expert for a token $x$, applying a softmax over the top-performing expert projections :
+
+$$G(x) = \text{Softmax}(\text{KeepTopK}(W_g x + H_{\text{noise}}(x), K)) \quad \text{[45]}$$
+
+where $W_g$ represents the gating parameters, and $H_{\text{noise}}$ is a tunable Gaussian noise matrix used to promote expert diversity during early training phases.
+
+A major challenge in MoE training is load balancing. Because routing decisions are learned end-to-end, routers are prone to a positive feedback loop where a small subset of experts is continuously selected. This causes the remaining experts to be underutilized, degrading the model's overall representational capacity. To enforce uniform expert utilization, models incorporate an auxiliary load-balancing loss $\mathcal{L}_{\text{aux}}$ across each batch :
+
+$$\mathcal{L}_{\text{aux}} = E \sum_{i=1}^E f_i \cdot P_i \quad \text{[45]}$$
+
+where $E$ is the number of experts, $f_i$ is the fraction of batch tokens routed to expert $i$, and $P_i$ is the fraction of the router's probability mass allocated to expert $i$.
+
+Recent architectures have refined this division of labor. DeepSeek designed a variant utilizing "shared experts" that are always active, alongside a set of "routed experts" that are conditionally selected. This configuration addresses a fundamental inefficiency of standard load-balanced MoEs: forcing experts to consult equally often causes them to redundantly master basic linguistic constructs like punctuation and grammar. By dedicating shared experts to invariant features, routed experts can specialize deeply in specific semantic domains.
+
+```
+DeepSeek-Style Expert Partitioning:
+Token Input -> [ Shared Experts (Invariant Features) ] -> [ Routed Experts (Semantic Specialization) ]
+```
+
+Despite their compute efficiency, MoE models demand massive memory footprints because the entire suite of experts must be loaded into memory during execution. This makes standard inference on a single GPU highly constrained, requiring distributed infrastructure.
+
+To train and run these networks, researchers leverage expert parallelism. Unlike standard data parallelism, expert parallelism partitions the experts across different physical devices, requiring tokens to be dynamically routed across a high-speed communication fabric. This introduces communication overhead, which is mitigated by optimizing the router batch capacity and token-to-expert mapping algorithms.
+
+## Conclusion: The Unified Mechanics of Sparsity
+
+The historical trajectory of natural language processing is defined by a continuous struggle against, and ultimate embrace of, the sparsity problem. In classical computational linguistics, discrete symbolic representations encountered a combinatorial wall, where the vast majority of potential word sequences were empty cells. Early statistical systems mitigated this discrete sparsity through heuristic smoothing and discounting, utilizing recursive Kneser-Ney continuation probabilities to allocate probability mass to unobserved events.
+
+The development of deep neural architectures resolved this symbolic barrier by mapping discrete tokens onto continuous latent manifolds. Within these low-dimensional Riemannian spaces, semantic similarity is encoded directly as geometric proximity, enabling models to interpolate across empty spaces. By utilizing the Fisher Information Metric, researchers can analyze this continuous-discrete boundary, characterizing the expressibility gap as a linear volume scaling law and intervening directly to stabilize token prediction.
+
+This representation efficiency is mirrored by biological brains, which employ dynamic sparse coding to minimize metabolic costs while preserving mutual information. In deep networks, this metabolic constraint is expressed via the superposition hypothesis, where models pack sparse features into non-orthogonal latent spaces. Analyzing these polysemantic spaces requires advanced interpretability tools like Subspace-Aware Sparse Autoencoders, which resolve feature splitting by consolidating multi-dimensional semantic concepts into coherent decoder subspaces.
+
+Ultimately, this structural sparsity is realized in modern hardware through Mixture of Experts architectures. By decoupling active parameter execution from total model capacity, MoE models scale representational intelligence while maintaining a flat computational footprint. Whether expressed through statistical smoothing, continuous manifold geometry, biological energy optimization, or hardware-aware routing, sparsity remains the foundational organizing principle of both biological and artificial intelligence.


### PR DESCRIPTION
This PR adds a new research document titled "The Sparsity Resolution" to the `autoresearch/` directory. It also improves the organization of the project documentation by moving the Autoresearch flow diagram (Mermaid) from the main `README.md` to the `autoresearch/README.md` file. Links to the new document have been added to both README files for easy navigation.

---
*PR created automatically by Jules for task [16792636170911594014](https://jules.google.com/task/16792636170911594014) started by @bob-friedman*